### PR TITLE
Feature/kit audit log

### DIFF
--- a/kit/azure/activity-log/README.md
+++ b/kit/azure/activity-log/README.md
@@ -10,7 +10,7 @@ compliance:
       storage and analysis.
 ---
 
-# activity log
+# Activity Log
 
 This documentation is intended as a reference documentation for cloud foundation or platform engineers using this module.
   

--- a/kit/azure/activity-log/README.md
+++ b/kit/azure/activity-log/README.md
@@ -1,0 +1,65 @@
+---
+name: Azure Activity Logs
+summary: |
+  This module sets up and Azure Log Analytics Workspace and activates collection of Azure Activity logs in all 
+  subscriptions under a parent management group. Subscriptions send all activitiy logs to this log workspace.
+compliance:
+  - control: cfmm/security-and-compliance/centralized-audit-logs
+    statement: |
+      Activates Azure Activity logs in all subscriptions and sends them to a central log analytics workspace for
+      storage and analysis.
+---
+
+# activity log
+
+This documentation is intended as a reference documentation for cloud foundation or platform engineers using this module.
+  
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_local"></a> [local](#provider\_local) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_log_analytics_workspace.law](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace) | resource |
+| [azurerm_management_group_policy_assignment.activity_log](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_policy_assignment) | resource |
+| [azurerm_management_group_subscription_association.logging](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_group_subscription_association) | resource |
+| [azurerm_resource_group.law_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.activity_log](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cloudfoundation_tfdeploy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.cloudfoundation_tfdeploy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_subscription.logging](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subscription) | resource |
+| [local_file.output_md](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [azurerm_policy_definition.activity_log](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/policy_definition) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_management_group_id"></a> [admin\_management\_group\_id](#input\_admin\_management\_group\_id) | id of the admin management group | `string` | n/a | yes |
+| <a name="input_cloudfoundation_deploy_principal_id"></a> [cloudfoundation\_deploy\_principal\_id](#input\_cloudfoundation\_deploy\_principal\_id) | something | `string` | n/a | yes |
+| <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | something | `number` | `30` | no |
+| <a name="input_output_md_file"></a> [output\_md\_file](#input\_output\_md\_file) | location of the file where this cloud foundation kit module generates its documentation output | `string` | n/a | yes |
+| <a name="input_platform_management_group_id"></a> [platform\_management\_group\_id](#input\_platform\_management\_group\_id) | id of the platform management group | `string` | n/a | yes |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | id of the logging subscription | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_assignment_id"></a> [assignment\_id](#output\_assignment\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/kit/azure/activity-log/documentation.tf
+++ b/kit/azure/activity-log/documentation.tf
@@ -1,0 +1,10 @@
+
+output "documentation_md" {
+  value  = <<EOF
+
+# Active Policies
+
+- **${data.azurerm_policy_definition.activity_log.display_name}**: ${data.azurerm_policy_definition.activity_log.description}
+
+EOF
+}

--- a/kit/azure/activity-log/main.tf
+++ b/kit/azure/activity-log/main.tf
@@ -1,24 +1,18 @@
+resource "azurecaf_name" "cafrandom_rg" {
+  name = var.resources_cloudfoundation
+  resource_type    = "azurerm_resource_group"
+  prefixes  = ["law"]
+  random_length = 3
+}
 
 # configure our logging subscription
 
 data "azurerm_subscription" "current" {
-
-}
-
-resource "azurerm_subscription" "logging" {
-  subscription_id   = var.subscription_id
-  subscription_name = "logging"
-  alias             = "logging"
-}
-
-resource "azurerm_management_group_subscription_association" "logging" {
-  management_group_id = var.admin_management_group_id
-  subscription_id     = data.azurerm_subscription.current.id
 }
 
 # Set up permissions for deploy user
 resource "azurerm_role_definition" "cloudfoundation_tfdeploy" {
-  name  = "cloudfoundation_tfdeploy"
+  name  = "${var.resources_cloudfoundation}_log_workspace"
   scope = data.azurerm_subscription.current.id
   permissions {
     actions = ["Microsoft.Resources/subscriptions/resourcegroups/write"]
@@ -37,8 +31,9 @@ resource "azurerm_resource_group" "law_rg" {
   depends_on = [
     azurerm_role_definition.cloudfoundation_tfdeploy
   ]
-  name     = "log-analytics-rg"
-  location = "Germany West Central"
+  name     = azurecaf_name.cafrandom_rg.result
+  location = var.location 
+
 }
 
 # Creates Log Anaylytics Workspace
@@ -90,6 +85,7 @@ locals {
     "Log Analytics Contributor"
   ])
 }
+
 resource "azurerm_role_assignment" "activity_log" {
   for_each = local.activity_log_remediation_roles
   role_definition_name = each.key

--- a/kit/azure/activity-log/main.tf
+++ b/kit/azure/activity-log/main.tf
@@ -60,7 +60,7 @@ data "azurerm_policy_definition" "activity_log" {
 
 resource "azurerm_management_group_policy_assignment" "activity_log" {
   name                 = "activity-log-policy"
-  management_group_id  = var.platform_management_group_id
+  management_group_id  = var.scope
   policy_definition_id = data.azurerm_policy_definition.activity_log.id
   description          = "Configure Azure Activity logs to stream to specified Log Analytics workspace"
   display_name         = "Stream Activity Logs to Log Analytics Workspace"
@@ -91,5 +91,5 @@ resource "azurerm_role_assignment" "activity_log" {
   role_definition_name = each.key
 
   principal_id = azurerm_management_group_policy_assignment.activity_log.identity[0].principal_id
-  scope = var.platform_management_group_id
+  scope = var.scope
 }

--- a/kit/azure/activity-log/main.tf
+++ b/kit/azure/activity-log/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_role_assignment" "cloudfoundation_tfdeploy" {
 }
 
 
-## Creates a RG for LAW
+# Creates a RG for LAW
 resource "azurerm_resource_group" "law_rg" {
   depends_on = [
     azurerm_role_definition.cloudfoundation_tfdeploy
@@ -37,7 +37,6 @@ resource "azurerm_resource_group" "law_rg" {
 }
 
 # Creates Log Anaylytics Workspace
-# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace
 resource "azurerm_log_analytics_workspace" "law" {
   name                = "log-analytics-workspace"
   location            = azurerm_resource_group.law_rg.location
@@ -77,7 +76,7 @@ resource "azurerm_management_group_policy_assignment" "activity_log" {
   }
 }
 
-# Configre Remediation
+# Configure Remediation
 
 locals {
   activity_log_remediation_roles = toset([

--- a/kit/azure/activity-log/main.tf
+++ b/kit/azure/activity-log/main.tf
@@ -8,6 +8,7 @@ resource "azurecaf_name" "cafrandom_rg" {
 # configure our logging subscription
 
 data "azurerm_subscription" "current" {
+  subscription_id = var.subscription_id
 }
 
 # Set up permissions for deploy user

--- a/kit/azure/activity-log/main.tf
+++ b/kit/azure/activity-log/main.tf
@@ -6,32 +6,12 @@ resource "azurecaf_name" "cafrandom_rg" {
 }
 
 # configure our logging subscription
-
 data "azurerm_subscription" "current" {
   subscription_id = var.subscription_id
 }
 
-# Set up permissions for deploy user
-resource "azurerm_role_definition" "cloudfoundation_tfdeploy" {
-  name  = "${var.resources_cloudfoundation}_log_workspace"
-  scope = data.azurerm_subscription.current.id
-  permissions {
-    actions = ["Microsoft.Resources/subscriptions/resourcegroups/write"]
-  }
-}
-
-resource "azurerm_role_assignment" "cloudfoundation_tfdeploy" {
-  principal_id       = var.cloudfoundation_deploy_principal_id
-  scope              = data.azurerm_subscription.current.id
-  role_definition_id = azurerm_role_definition.cloudfoundation_tfdeploy.role_definition_resource_id
-}
-
-
 # Creates a RG for LAW
 resource "azurerm_resource_group" "law_rg" {
-  depends_on = [
-    azurerm_role_definition.cloudfoundation_tfdeploy
-  ]
   name     = azurecaf_name.cafrandom_rg.result
   location = var.location 
 

--- a/kit/azure/activity-log/main.tf
+++ b/kit/azure/activity-log/main.tf
@@ -1,0 +1,99 @@
+
+# configure our logging subscription
+
+data "azurerm_subscription" "current" {
+
+}
+
+resource "azurerm_subscription" "logging" {
+  subscription_id   = var.subscription_id
+  subscription_name = "logging"
+  alias             = "logging"
+}
+
+resource "azurerm_management_group_subscription_association" "logging" {
+  management_group_id = var.admin_management_group_id
+  subscription_id     = data.azurerm_subscription.current.id
+}
+
+# Set up permissions for deploy user
+resource "azurerm_role_definition" "cloudfoundation_tfdeploy" {
+  name  = "cloudfoundation_tfdeploy"
+  scope = data.azurerm_subscription.current.id
+  permissions {
+    actions = ["Microsoft.Resources/subscriptions/resourcegroups/write"]
+  }
+}
+
+resource "azurerm_role_assignment" "cloudfoundation_tfdeploy" {
+  principal_id       = var.cloudfoundation_deploy_principal_id
+  scope              = data.azurerm_subscription.current.id
+  role_definition_id = azurerm_role_definition.cloudfoundation_tfdeploy.role_definition_resource_id
+}
+
+
+## Creates a RG for LAW
+resource "azurerm_resource_group" "law_rg" {
+  depends_on = [
+    azurerm_role_definition.cloudfoundation_tfdeploy
+  ]
+  name     = "log-analytics-rg"
+  location = "Germany West Central"
+}
+
+# Creates Log Anaylytics Workspace
+# https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace
+resource "azurerm_log_analytics_workspace" "law" {
+  name                = "log-analytics-workspace"
+  location            = azurerm_resource_group.law_rg.location
+  resource_group_name = azurerm_resource_group.law_rg.name
+  sku                 = "PerGB2018"
+  retention_in_days   = var.log_retention_in_days
+}
+
+# Deploy "Configure Azure Activity logs to stream to specified Log Analytics workspace" Policy definition
+
+locals {
+  builtin_azurerm_policy_definition_names = {
+    activity_log = "2465583e-4e78-4c15-b6be-a36cbc7c8b0f"
+  }
+}
+
+data "azurerm_policy_definition" "activity_log" {
+  name = local.builtin_azurerm_policy_definition_names.activity_log
+}
+
+resource "azurerm_management_group_policy_assignment" "activity_log" {
+  name                 = "activity-log-policy"
+  management_group_id  = var.platform_management_group_id
+  policy_definition_id = data.azurerm_policy_definition.activity_log.id
+  description          = "Configure Azure Activity logs to stream to specified Log Analytics workspace"
+  display_name         = "Stream Activity Logs to Log Analytics Workspace"
+  location             = azurerm_resource_group.law_rg.location
+  
+  parameters = jsonencode({
+    logAnalytics = {
+      value = azurerm_log_analytics_workspace.law.id
+    }
+  })
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+# Configre Remediation
+
+locals {
+  activity_log_remediation_roles = toset([
+    "Monitoring Contributor", 
+    "Log Analytics Contributor"
+  ])
+}
+resource "azurerm_role_assignment" "activity_log" {
+  for_each = local.activity_log_remediation_roles
+  role_definition_name = each.key
+
+  principal_id = azurerm_management_group_policy_assignment.activity_log.identity[0].principal_id
+  scope = var.platform_management_group_id
+}

--- a/kit/azure/activity-log/outputs.tf
+++ b/kit/azure/activity-log/outputs.tf
@@ -1,0 +1,3 @@
+output "assignment_id" {
+    value = azurerm_management_group_policy_assignment.activity_log.id
+}

--- a/kit/azure/activity-log/template/platform-module/terragrunt.hcl
+++ b/kit/azure/activity-log/template/platform-module/terragrunt.hcl
@@ -1,0 +1,30 @@
+include "platform" {
+  path = find_in_parent_folders("platform.hcl")
+  expose = true
+}
+
+include "module" {
+  path = find_in_parent_folders("module.hcl")
+}
+
+terraform {
+  source = "${get_repo_root()}//kit/azure/activity-log"
+}
+
+dependency "bootstrap" {
+  config_path = "../bootstrap"
+  }
+
+dependency "organization-hierarchy" {
+  config_path = "../organization-hierarchy"
+}
+
+inputs = {
+  # todo: set input variables
+  admin_management_group_id           = "${dependency.organization-hierarchy.outputs.platform_id}"
+  cloudfoundation_deploy_principal_id = "${dependency.bootstrap.outputs.client_id}"
+  log_retention_in_days               = 30
+  platform_management_group_id        = "${dependency.organization-hierarchy.outputs.management_id}"
+  subscription_id                     = "${include.platform.locals.platform.azure.subscriptionId}"
+  
+}

--- a/kit/azure/activity-log/template/platform-module/terragrunt.hcl
+++ b/kit/azure/activity-log/template/platform-module/terragrunt.hcl
@@ -25,6 +25,6 @@ inputs = {
   cloudfoundation_deploy_principal_id = "${dependency.bootstrap.outputs.client_principal_id}"
   subscription_id                     = "${include.platform.locals.platform.azure.subscriptionId}"
   resources_cloudfoundation           = "${dependency.bootstrap.outputs.resources_cloudfoundation}"
-  location                            = "${try(include.platform.locals.tfstateconfig.location, "")}"
+  location                            = "${try(include.platform.locals.tfstateconfig.location, "could not read location from stateconfig. configure it explicitly")}"
   log_retention_in_days               = 30
 }

--- a/kit/azure/activity-log/template/platform-module/terragrunt.hcl
+++ b/kit/azure/activity-log/template/platform-module/terragrunt.hcl
@@ -21,9 +21,8 @@ dependency "organization-hierarchy" {
 
 inputs = {
   # todo: set input variables
-  admin_management_group_id           = "${dependency.organization-hierarchy.outputs.parent_id}"
+  scope                               = "${dependency.organization-hierarchy.outputs.parent_id}"
   cloudfoundation_deploy_principal_id = "${dependency.bootstrap.outputs.client_principal_id}"
-  platform_management_group_id        = "${dependency.organization-hierarchy.outputs.platform_id}"
   subscription_id                     = "${include.platform.locals.platform.azure.subscriptionId}"
   resources_cloudfoundation           = "${dependency.bootstrap.outputs.resources_cloudfoundation}"
   location                            = "${try(include.platform.locals.tfstateconfig.location, "")}"

--- a/kit/azure/activity-log/template/platform-module/terragrunt.hcl
+++ b/kit/azure/activity-log/template/platform-module/terragrunt.hcl
@@ -21,10 +21,11 @@ dependency "organization-hierarchy" {
 
 inputs = {
   # todo: set input variables
-  admin_management_group_id           = "${dependency.organization-hierarchy.outputs.platform_id}"
-  cloudfoundation_deploy_principal_id = "${dependency.bootstrap.outputs.client_id}"
-  log_retention_in_days               = 30
-  platform_management_group_id        = "${dependency.organization-hierarchy.outputs.management_id}"
+  admin_management_group_id           = "${dependency.organization-hierarchy.outputs.parent_id}"
+  cloudfoundation_deploy_principal_id = "${dependency.bootstrap.outputs.client_principal_id}"
+  platform_management_group_id        = "${dependency.organization-hierarchy.outputs.platform_id}"
   subscription_id                     = "${include.platform.locals.platform.azure.subscriptionId}"
-  
+  resources_cloudfoundation           = "${dependency.bootstrap.outputs.resources_cloudfoundation}"
+  location                            = "${try(include.platform.locals.tfstateconfig.location, "")}"
+  log_retention_in_days               = 30
 }

--- a/kit/azure/activity-log/variables.tf
+++ b/kit/azure/activity-log/variables.tf
@@ -1,0 +1,29 @@
+variable "subscription_id" {
+  type        = string
+  nullable    = false
+  description = "id of the logging subscription"
+}
+
+variable "platform_management_group_id" {
+  type        = string
+  nullable    = false
+  description = "id of the platform management group"
+}
+
+variable "admin_management_group_id" {
+  type        = string
+  nullable    = false
+  description = "id of the admin management group"
+}
+
+variable "cloudfoundation_deploy_principal_id" {
+  type        = string
+  nullable    = false
+  description = "something"
+}
+variable "log_retention_in_days" {
+  type        = number
+  nullable    = false
+  description = "something"
+  default     = 30
+}

--- a/kit/azure/activity-log/variables.tf
+++ b/kit/azure/activity-log/variables.tf
@@ -4,16 +4,10 @@ variable "subscription_id" {
   description = "id of the logging subscription"
 }
 
-variable "platform_management_group_id" {
+variable "scope" {
   type        = string
   nullable    = false
-  description = "id of the platform management group"
-}
-
-variable "admin_management_group_id" {
-  type        = string
-  nullable    = false
-  description = "id of the admin management group"
+  description = "id of the management group that you want to log"
 }
 
 variable "cloudfoundation_deploy_principal_id" {

--- a/kit/azure/activity-log/variables.tf
+++ b/kit/azure/activity-log/variables.tf
@@ -19,11 +19,23 @@ variable "admin_management_group_id" {
 variable "cloudfoundation_deploy_principal_id" {
   type        = string
   nullable    = false
-  description = "something"
+  description = "service principal id"
 }
 variable "log_retention_in_days" {
   type        = number
   nullable    = false
-  description = "something"
+  description = "amount of time of log retention"
   default     = 30
+}
+
+variable "resources_cloudfoundation" {
+  type = string
+  nullable = false
+  description = "tfstate resource group for the statefiles"
+}
+
+variable "location" {
+  type = string
+  nullable = false
+  description = "location of the resources"
 }

--- a/kit/azure/activity-log/version.tf
+++ b/kit/azure/activity-log/version.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    azurecaf = {
+      source = "aztfmod/azurecaf"
+      version = "~> 1.2.26"
+    }
+  }
+}

--- a/kit/azure/bootstrap/main.tf
+++ b/kit/azure/bootstrap/main.tf
@@ -11,7 +11,7 @@ module "terraform_state" {
   source          = "./terraform-state"
   location        = var.terraform_state_storage.location
   file_path       = var.file_path
-  resources_tfstate = var.resources_tfstate
+  resources_cloudfoundation = var.resources_cloudfoundation
 }
 
 # Set permissions on the blob store

--- a/kit/azure/bootstrap/outputs.tf
+++ b/kit/azure/bootstrap/outputs.tf
@@ -6,4 +6,12 @@ output "client_secret" {
   value     = azuread_service_principal_password.cloudfoundation_deploy.value
   sensitive = true
 }
+
+output "client_principal_id" {
+  value = azuread_service_principal.cloudfoundation_deploy.id
+}
+
+output "resources_cloudfoundation" {
+  value = var.resources_cloudfoundation
+}
 	

--- a/kit/azure/bootstrap/template/platform-module/terragrunt.hcl
+++ b/kit/azure/bootstrap/template/platform-module/terragrunt.hcl
@@ -41,7 +41,7 @@ inputs = {
   # https://registry.terraform.io/providers/aztfmod/azurecaf/latest/docs/resources/azurecaf_naming_convention
   # you only need the the name of your foundation like likvid the result would like rg-tfstate-likvid-ewt
 
-  resources_tfstate = "cloudfoundation" #TODO change, name your rg fo the statefiles
+  resources_cloudfoundation = "cloudfoundation" #TODO change, name your rg fo the statefiles
   service_principal_name = "cloudfoundation_tf_deploy" #TODO change, name your spn
   
   terraform_state_storage = {

--- a/kit/azure/bootstrap/template/platform/platform.hcl
+++ b/kit/azure/bootstrap/template/platform/platform.hcl
@@ -1,7 +1,7 @@
 locals {
 # define shared configuration here that's included by all terragrunt configurations in this locals 
   platform = yamldecode(regex("^---([\\s\\S]*)\\n---\\n[\\s\\S]*$", file(".//README.md"))[0])
-  file_path   = "${get_parent_terragrunt_dir()}/${path_relative_to_include()}/tfstates-config.yml"
+  file_path   = "${get_parent_terragrunt_dir()}/tfstates-config.yml"
   tfstateconfig = try(yamldecode(file(local.file_path)), [])
 }
 

--- a/kit/azure/bootstrap/terraform-state/main.tf
+++ b/kit/azure/bootstrap/terraform-state/main.tf
@@ -1,11 +1,11 @@
 resource "azurecaf_name" "cafrandom_rg" {
-  name = var.resources_tfstate
+  name = var.resources_cloudfoundation
   resource_type    = "azurerm_resource_group"
   prefixes  = ["tfstate"]
   random_length = 3
 }
 resource "azurecaf_name" "cafrandom_st" {
-  name = var.resources_tfstate
+  name = var.resources_cloudfoundation
   resource_type    = "azurerm_storage_account"
   prefixes  = ["tfstate"]
   random_length = 3
@@ -36,6 +36,7 @@ resource "local_file" "tfstates_yaml" {
   content  = <<-EOT
     storage_account_name: ${azurecaf_name.cafrandom_st.result}
     container_name: ${azurerm_storage_container.tfstates.name}
+    location: ${azurerm_storage_account.tfstates.location}
     resource_group_name: ${azurecaf_name.cafrandom_rg.result}
 
   EOT

--- a/kit/azure/bootstrap/terraform-state/outputs.tf
+++ b/kit/azure/bootstrap/terraform-state/outputs.tf
@@ -14,3 +14,7 @@ output "storage_account_name" {
 output "container_name" {
   value = azurerm_storage_container.tfstates.name
 }
+
+output "location" {
+  value = azurerm_resource_group.tfstates.location
+}

--- a/kit/azure/bootstrap/terraform-state/variables.tf
+++ b/kit/azure/bootstrap/terraform-state/variables.tf
@@ -10,7 +10,7 @@ variable "file_path" {
   description = "tfstate-config file for running the bootstrap"
 }
 
-variable "resources_tfstate" {
+variable "resources_cloudfoundation" {
   type = string
   nullable = false
   description = "tfstate resource group for the statefiles"

--- a/kit/azure/bootstrap/variables.tf
+++ b/kit/azure/bootstrap/variables.tf
@@ -32,7 +32,7 @@ variable "file_path" {
   description = "tfstate-config file for running the bootstrap"
 }
 
-variable "resources_tfstate" {
+variable "resources_cloudfoundation" {
   type        = string
   nullable    = false
   description = "tfstate resource group for the statefiles"


### PR DESCRIPTION
I removed the own subscription for logging until i spoked to @tfelix. The kit brings a own terragrunt template file which fetch all needed vars out of the bootstrap.  