### PR TITLE
fix: disable anonymous access

### DIFF
--- a/kit/azure/bootstrap/terraform-state/main.tf
+++ b/kit/azure/bootstrap/terraform-state/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_storage_account" "tfstates" {
 resource "azurerm_storage_container" "tfstates" {
   name                  = "tfstates"
   storage_account_name  = azurerm_storage_account.tfstates.name
-  container_access_type = "blob"
+  container_access_type = "private"
 }
 
 resource "local_file" "tfstates_yaml" {


### PR DESCRIPTION
We don't want to allow [anonymous read access](https://learn.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure?tabs=portal) for the tf states.

Argument reference of azurerm provider: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container#argument-reference