### PR TITLE
feat: add starterkit building block from Likvid Bank implementation

### DIFF
--- a/kit/buildingblocks/starterkit/README.md
+++ b/kit/buildingblocks/starterkit/README.md
@@ -1,0 +1,226 @@
+---
+name: Starter Kits
+summary: |
+  Offers templates for application teams to get started quickly with deploying their applications on the cloud while following best practices.
+compliance:
+- control: cfmm/service-ecosystem/managed-devops-toolchain
+  statement: |
+    Provides a GitHub repository set up to deploy against Azure Subscriptions using Workload Identity Federation.
+- control: cfmm/iam/service-account-management
+  statement:  |
+    Automatically manages service principals for CI/CD pipelines using Workload Identity Federation.
+---
+
+# Starter Kits
+
+This is an implementation of "Cloud Starter Kits" that provides application teams with
+
+- a GitHub repository, seeded with an application starter kit
+- a GitHub actions pipeline
+- a service account solution that enables the GitHub actions pipeline to deploy to their Azure Subscription
+
+## Prerequisites
+
+### GitHub App
+
+Apart from an Azure Landing Zone (we recommend using starter kits only with Sandbox Landing Zones) you will need a
+GitHub organization and the ability to [create and install a private GitHub App](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) on the organization. This app will need the following permissions
+
+- Permissions
+  -  `Read access to metadata and organization administration`
+  - ` Read and write access to actions, administration, code, secrets, and workflows`
+- Repository access: `All repositories`
+
+You will also need to generate a private key `.PEM` file for the app to be used by the [github terraform provider](https://registry.terraform.io/providers/integrations/github/latest/docs#github-app-installation) when deploying instances of the `buildingblock/` module.
+
+
+### Template Repository
+
+You will also need a template repository that contains code and GitHub actions pipelines. The "official example"
+that we use for testing is [likvid-bank/starterkit-template-azure-static-website](https://github.com/likvid-bank/starterkit-template-azure-static-website).
+This template sets up an Azure Static Website including a PR workflow for terraform and code.
+
+## Structure of this Kit module
+
+This kit module comes with three components, each responsible for enabling deployment of the next
+
+- the kit module itself, acting as the building block's "backplane" that sets up all required infrastructure for deploying starterkits for application teams
+- a terraform module that forms the definition for each "building block", i.e. the instance of the starterkit deployed for a particular application team including a GitHub repo and GitHub actions pipeline
+- terraform code that lives in the starterkit template, deployed by a GitHub actions pipeline
+
+The following sections explain these parts in more detail
+
+### Deployment of the Building Block backplane
+
+Before we can deploy building blocks, we need to first set up the backplane. This operation is only performed once by deploying this kit module using collie as any other kit module with `collie kit apply` and `collie foundation deploy`.
+
+> Unforutnately it's currently not possible to setup a GitHub app via terraform, so please perform this manually.
+
+This will deploy the following resources:
+
+```mermaid
+flowchart TD
+  subgraph github[GitHub Organization]
+    ghapp[GitHub App]
+    ghrepotemplate[GitHub Template Repository]
+  end
+  subgraph Azure
+    subgraph bbsub[Building Block Backplane Subscription]
+      bbsubtfstate[StarterKit BB TF State]
+      bbspn[StarterKit SPN]
+
+    end
+  end
+
+  BB((Starter Kit<br>Building Block))
+
+  BB --> github
+  BB --> Azure
+  bbspn --Storage Blob Owner--> bbsubtfstate
+
+
+```
+
+### Deployment of a Building Block
+
+Now that we the backplane deployed, we can use the backplane to deploy an instance of the [buildingblock](./buildingblock/) terraform module into a sandbox subscription supplied by the application team.
+The easiest way to do this is to create a building block definition from the `buildingblock` terraform module in meshStack and configure it with the `config_tf` file produced by the backplane module.
+
+The chart below shows the interaction of cloud resources when deploying a new building block using the backplane:
+
+```mermaid
+flowchart TD
+  subgraph GitHub[GitHub Organization]
+    ghapp[GitHub App]
+    subgraph ghrepo [GitHub Repo]
+      ghpipeline[Deploy Pipeline]
+    end
+    ghrepotemplate[GitHub Template Repository]
+  end
+  subgraph Azure
+    subgraph bbsub[Building Block Backplane Subscription]
+      bbsubtfstate[StarterKit BB TF State]
+      bbspn[StarterKit SPN]
+
+    end
+    subgraph sbsub[Sandbox Subscription]
+      subgraph rgcicd[Resource Group ci-cd]
+        ghactionsuami[UAMI for GitHub Actions]
+        sbsubtfstate[Pipeline TF State]
+      end
+      subgraph rgapp[Resource Group app]
+        staticwebsite
+      end
+    end
+  end
+
+  BB((Starter Kit Building Block))
+
+  ghapp -.deploys.-> ghrepo
+  bbspn -.deploys.-> rgcicd
+  bbspn -.deploys.-> rgapp
+  BB -.via github provider.-> ghapp
+  BB -.via azurerm provider.-> bbspn
+  ghrepotemplate -.from template.-> ghrepo
+  ghactionsuami --Storage Blob Owner--> sbsubtfstate
+  ghpipeline --Workload Identity Federation--> ghactionsuami
+  bbspn --Storage Blob Owner--> bbsubtfstate
+  ghactionsuami --Owner--> rgapp
+
+  linkStyle 0,1,2,3,4,5 stroke:#ff3,stroke-width:4px;
+```
+
+## Deployment of the App
+
+Now that we have the application team's sandbox subscription and their GitHub repository configured, the team can use the setup to deploy their `staticwebsite` app.
+
+```mermaid
+flowchart TD
+  subgraph GitHub[GitHub Organization]
+    subgraph ghrepo [GitHub Repo]
+      ghpipeline[Deploy Pipeline]
+    end
+  end
+  subgraph Azure
+    subgraph sbsub[Sandbox Subscription]
+      subgraph rgcicd[Resource Group ci-cd]
+        ghactionsuami[UAMI for GitHub Actions]
+        sbsubtfstate[Pipeline TF State]
+      end
+      subgraph rgapp[Resource Group app]
+        staticwebsite
+      end
+    end
+  end
+
+  ghactionsuami -.deploys.-> staticwebsite
+
+  ghactionsuami --Storage Blob Owner--> sbsubtfstate
+  ghpipeline --Workload Identity Federation--> ghactionsuami
+  ghactionsuami --Owner--> rgapp
+
+  linkStyle 0 stroke:#ff3,stroke-width:4px;
+
+```
+
+## Creating Custom Starter Kits
+
+Using this kit module as a template, you can quickly develop similar starter kits.
+You will typically only need to customize the template repository with code and GitHub Actions workflows.
+
+For advanced use cases, you can of course also want to customize the `buildingblock/` terraform module itself or even the backplane terraform module.
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | ~> 2.46.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.71.0 |
+| <a name="requirement_github"></a> [github](#requirement\_github) | ~> 5.42.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azuread_app_role_assignment.starterkit-directory](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
+| [azuread_application.starterkit](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
+| [azuread_service_principal.starterkit](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
+| [azuread_service_principal_password.starterkit](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_resource_group.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.starterkit_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.terraform_state](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.starterkit_access](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.starterkit_deploy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_storage_account.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.tfstates](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [github_repository.staticwebsite_template](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository) | resource |
+| [random_string.resource_code](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [time_rotating.key_rotation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
+| [azuread_application_published_app_ids.well_known](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application_published_app_ids) | data source |
+| [azuread_group.project_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_service_principal.msgraph](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_github_app_id"></a> [github\_app\_id](#input\_github\_app\_id) | id of your GitHub App | `number` | n/a | yes |
+| <a name="input_github_app_installation_id"></a> [github\_app\_installation\_id](#input\_github\_app\_installation\_id) | id of your GitHub App installation as it appears in URLs on GitHub.com | `number` | n/a | yes |
+| <a name="input_github_org"></a> [github\_org](#input\_github\_org) | id of your GitHub organization as it appears in URLs on GitHub.com | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Azure location for deploying the building block terraform state storage account | `string` | n/a | yes |
+| <a name="input_scope"></a> [scope](#input\_scope) | Scope where the building block should be deployable, typically a Sandbox Landing Zone Management Group | `string` | n/a | yes |
+| <a name="input_service_principal_name"></a> [service\_principal\_name](#input\_service\_principal\_name) | name of the Service Principal used to perform all deployments of this building block | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_config_tf"></a> [config\_tf](#output\_config\_tf) | Generates a config.tf that can be dropped into meshStack's BuildingBlockDefinition as an encrypted file input to configure this building block. |
+| <a name="output_documentation_md"></a> [documentation\_md](#output\_documentation\_md) | n/a |
+<!-- END_TF_DOCS -->

--- a/kit/buildingblocks/starterkit/buildingblock/.gitignore
+++ b/kit/buildingblocks/starterkit/buildingblock/.gitignore
@@ -1,0 +1,8 @@
+# ignore local files that allow connecting the local terraform environment to this building block's backend and providers
+config.tf
+likvid-bank-devops-toolchain-team.private-key.pem
+terraform.tfvars
+
+# todo: ideally this ought to be comitted & locked to the runners OS (linux) but we curently don't have the process in place
+# to ensure this when running from a different development environment (e.g. macOS), so we leave it out for now
+.terraform.lock.hcl

--- a/kit/buildingblocks/starterkit/buildingblock/main.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/main.tf
@@ -1,0 +1,33 @@
+data "azurerm_subscription" "current" {}
+data "azuread_client_config" "current" {}
+
+# note: it's important that all other azure resources transitively depend on this role assignment or else they will fail
+resource "azurerm_role_assignment" "starterkit_deploy" {
+  # since the role is defined on MG level, we need to prefix the subscription id here to make terraform happy and not plan replacements
+  # see https://github.com/hashicorp/terraform-provider-azurerm/issues/19847#issuecomment-1407262429
+  role_definition_id = "${data.azurerm_subscription.current.id}${local.deploy_role_definition_id}"
+
+  description  = "Grant permissions to deploy a starterkit building block."
+  principal_id = data.azuread_client_config.current.object_id
+  scope        = data.azurerm_subscription.current.id
+}
+
+#
+# configure developer acess
+#
+
+# note: this group is managed via meshStack and provided as part of the sandbox landing zone
+data "azuread_group" "project_admins" {
+  display_name = "${var.workspace_identifier}.${var.project_identifier}-admin"
+}
+
+# rationale: normal uses with "Project User" role should only deploy code via the pipeline and therefore don't need
+# access to terraform state, but users wotj "Project Admin" role should be able to debug terraform issues and therefore
+# work with the state directly
+resource "azurerm_role_assignment" "project_admins_blobs" {
+  role_definition_name = "Storage Blob Data Owner"
+  description          = "Allow developer assigned the 'Project Admin' role via meshStack to work directly with terraform state"
+
+  principal_id = data.azuread_group.project_admins.object_id
+  scope        = azurerm_storage_container.tfstates.resource_manager_id
+}

--- a/kit/buildingblocks/starterkit/buildingblock/outputs.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_html_url" {
+  value = github_repository.repository.html_url
+}

--- a/kit/buildingblocks/starterkit/buildingblock/resources.azure.app.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/resources.azure.app.tf
@@ -1,0 +1,34 @@
+resource "azurerm_resource_group" "app" {
+  depends_on = [azurerm_role_assignment.starterkit_deploy]
+
+  name     = "app"
+  location = var.location
+}
+
+# WARNING: this shows _one_ way of setting up permissions for the github pipeline by confining it to a single resource
+# group. We deliberately allow every action in that resource group because we want to encourage application teams to
+# experiment with deploying different resources via the pipeline.
+#
+# Application teams using this starter kit as a "fork and own" template for setting up their own pipelines for
+# proper application development (including production use) should use more specific permissions.
+# See https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/secure/best-practices/secure-devops for a good
+# overview to customize to your individual needs.
+resource "azurerm_role_definition" "ghactions" {
+  name              = "github-action-deployment"
+  description       = "Permissions for the ${azurerm_user_assigned_identity.ghactions.name} UAMI to create/modify/delete resources in this resource group"
+  scope             = azurerm_resource_group.app.id
+  assignable_scopes = [azurerm_resource_group.app.id]
+
+  permissions {
+    actions = [
+      "*"
+    ]
+    not_actions = []
+  }
+}
+
+resource "azurerm_role_assignment" "ghactions_app" {
+  role_definition_id = azurerm_role_definition.ghactions.role_definition_resource_id
+  scope              = azurerm_resource_group.app.id
+  principal_id       = azurerm_user_assigned_identity.ghactions.principal_id
+}

--- a/kit/buildingblocks/starterkit/buildingblock/resources.azure.cicd.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/resources.azure.cicd.tf
@@ -1,0 +1,63 @@
+resource "azurerm_resource_group" "cicd" {
+  depends_on = [azurerm_role_assignment.starterkit_deploy]
+
+  name     = "ci-cd"
+  location = var.location
+}
+
+#
+# Terraform State Storage
+#
+
+resource "random_string" "resource_code" {
+  length  = 5
+  special = false
+  upper   = false
+}
+
+resource "azurerm_storage_account" "tfstates" {
+  name                      = "tfstates${random_string.resource_code.result}"
+  resource_group_name       = azurerm_resource_group.cicd.name
+  location                  = azurerm_resource_group.cicd.location
+  account_tier              = "Standard"
+  account_replication_type  = "GRS"
+  shared_access_key_enabled = false
+}
+
+resource "azurerm_storage_container" "tfstates" {
+  name                  = "tfstates"
+  storage_account_name  = azurerm_storage_account.tfstates.name
+  container_access_type = "blob"
+}
+
+#
+# set up an UAMI for the github actions pipeline to use
+#
+
+resource "azurerm_user_assigned_identity" "ghactions" {
+  name                = "github-actions"
+  location            = azurerm_resource_group.cicd.location
+  resource_group_name = azurerm_resource_group.cicd.name
+}
+
+# see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure#adding-the-federated-credentials-to-azure
+resource "azurerm_federated_identity_credential" "ghactions" {
+  parent_id           = azurerm_user_assigned_identity.ghactions.id
+  resource_group_name = azurerm_resource_group.cicd.name
+
+  name     = "github-actions"
+  audience = ["api://AzureADTokenExchange"]
+  issuer   = "https://token.actions.githubusercontent.com"
+
+  # see ../resources.github.tf for how the BB backplane sets up a "sandbox" environment for each deployment
+  subject = "repo:${github_repository.repository.full_name}:environment:${github_repository_environment.sandbox.environment}"
+}
+
+resource "azurerm_role_assignment" "ghaction_tfstate" {
+  role_definition_name = "Storage Blob Data Owner"
+  description          = "allows the ${azurerm_user_assigned_identity.ghactions.name} UAMI to read/write terraform state"
+
+  principal_id = azurerm_user_assigned_identity.ghactions.principal_id
+  scope        = azurerm_storage_container.tfstates.resource_manager_id
+}
+

--- a/kit/buildingblocks/starterkit/buildingblock/resources.github.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/resources.github.tf
@@ -1,0 +1,113 @@
+# note: this building block is expected to be executed with a config.tf file as output by the "backplane" module in the
+# parent dir, this needs to provided in the BB execution enviornment
+
+resource "github_repository" "repository" {
+  name        = var.repo_name
+  description = "Created from a Likvid Bank DevOps Toolchain starter kit for ${var.workspace_identifier}.${var.project_identifier}"
+  visibility  = "private"
+
+  topics = ["starterkit"]
+
+  auto_init            = true
+  vulnerability_alerts = true
+
+  lifecycle {
+    ignore_changes = [description]
+  }
+
+  template {
+    owner      = var.template_owner
+    repository = var.template_repo
+  }
+}
+
+# In theory these settings could also be copied from the template repository, however it's unclear whether this is
+# supported for every setting we care about. Having them in the BB instead of the backplane has the following benefits
+# - we can decide to upgrade these rules on existing repos with a BB definition version upgrade
+# - we have important concepts like the sandbox environment available for cross-referencing in other resources and don't
+#   need "magic constants" here
+
+resource "github_repository_environment" "sandbox" {
+  environment = "sandbox"
+  repository  = github_repository.repository.name
+
+  deployment_branch_policy {
+    protected_branches     = false
+    custom_branch_policies = true
+  }
+}
+
+# we currently don't set up a separate prod/non-prod enviornment on GitHub as that would require giving the UAMI
+# two sets of permissions as well - this would be great for production use cases but complicates this starter kit
+# Azure/static-web-apps-deploy@v1 implements proper staging for PR previews
+resource "github_repository_environment_deployment_policy" "sandbox_all" {
+  repository     = github_repository.repository.name
+  environment    = github_repository_environment.sandbox.environment
+  branch_pattern = "*"
+}
+
+#
+# Files
+#
+
+
+#
+# add pipeline file to repo
+#
+
+locals {
+  commit_author = "DevOps Toolchain Team"
+  commit_email  = "devopstoolchain@likvid-bank.com"
+}
+
+resource "github_repository_file" "provider_tf" {
+  repository     = github_repository.repository.name
+  commit_message = "Configuring azurerm provider to deploy to your subscription"
+  commit_author  = local.commit_author
+  commit_email   = local.commit_email
+
+  file    = "infra/provider.tf"
+  content = <<-EOT
+provider "azurerm" {
+  features {}
+  skip_provider_registration = false
+  tenant_id                  = "${data.azurerm_subscription.current.tenant_id}"
+  subscription_id            = "${data.azurerm_subscription.current.subscription_id}"
+  storage_use_azuread        = true
+}
+
+provider "azuread" {
+ tenant_id                  = "${data.azurerm_subscription.current.tenant_id}"
+}
+EOT
+}
+
+resource "github_repository_file" "backend_tf" {
+  repository     = github_repository.repository.name
+  commit_message = "Configuring terraform backend to store state in your subscription"
+  commit_author  = local.commit_author
+  commit_email   = local.commit_email
+
+  file    = "infra/backend.tf"
+  content = <<-EOT
+terraform {
+  backend "azurerm" {
+    use_azuread_auth      = true
+    tenant_id             = "${data.azurerm_subscription.current.tenant_id}"
+    subscription_id       = "${data.azurerm_subscription.current.subscription_id}"
+    resource_group_name   = "${azurerm_resource_group.cicd.name}"
+    storage_account_name  = "${azurerm_storage_account.tfstates.name}"
+    container_name        = "${azurerm_storage_container.tfstates.name}"
+    key                   = "starterkit.tfstate"
+  }
+}
+EOT
+}
+
+# pass the UAMI client id as a secret, not because it's secret, but because this allows us to have an easy interface with
+# template repositories (we can keep workflow files in the template repos and don't need to generate them via terraform)
+resource "github_actions_secret" "arm_client_id" {
+  repository      = github_repository.repository.name
+  secret_name     = "ARM_CLIENT_ID"
+  plaintext_value = azurerm_user_assigned_identity.ghactions.client_id
+}

--- a/kit/buildingblocks/starterkit/buildingblock/variables.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/variables.tf
@@ -1,0 +1,34 @@
+variable "repo_name" {
+  type    = string
+  default = "name of the created repository"
+}
+
+variable "visibility" {
+  type    = string
+  default = "private"
+}
+
+variable "template_owner" {
+  type = string
+}
+
+variable "template_repo" {
+  type = string
+}
+
+variable "workspace_identifier" {
+  type = string
+}
+
+variable "project_identifier" {
+  type = string
+}
+
+variable "subscription_id" {
+  type = string
+}
+
+variable "location" {
+  type    = string
+  default = "westeurope"
+}

--- a/kit/buildingblocks/starterkit/buildingblock/versions.tf
+++ b/kit/buildingblocks/starterkit/buildingblock/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.42.0"
+    }
+
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.71.0"
+    }
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.46.0"
+    }
+  }
+}
+

--- a/kit/buildingblocks/starterkit/documentation.tf
+++ b/kit/buildingblocks/starterkit/documentation.tf
@@ -1,0 +1,34 @@
+output "documentation_md" {
+  value = <<EOF
+# Starter Kit Building Blocks
+
+The Likvid Bank DevOps Toolchain team maintains a set of starter kits to help application teams get started
+on the cloud quickly.
+
+"Cloud Starter Kits" provide application teams with
+
+- a GitHub repository, seeded with an application starter kit
+- a GitHub actions pipeline
+- a service account solution that enables the GitHub actions pipeline to deploy to your Azure Subscription
+
+## How to work with a Starter Kit
+
+> Starter Kits are meant to be used in [Sandbox Landing Zones](./azure-landingzones-sandbox.md) for learning and experimentation only.
+
+The easiest way to get started with a Starter Kit is to search for "Starter Kit" in the Likvid Bank Cloud Portal
+Marketplace and let the portal help you add it to a Sandbox Subscription (or create a new one if you don't have one yet).
+
+Starter Kits will create a (private) GitHub repository for you in our [GitHub Organization](https://github.com/${var.github_org}).
+You will find the URL for your repository in the Starter Kit building block output tab. Please review the `README.md`
+of that repository for further instructions and inspiration for working with the starter kit.
+
+## Next Steps when using a Starter Kit
+
+Once you are happy with your results, please provision a [Cloud-Native Landing Zone](./azure-landingzones-cloud-native.md) and fork-and-own the
+starter kit template, including the infrastructure set up by the starter kit building block. We recommend this policy,
+because for productive use cases you will eventually need to customize the way your CI/CD pipeline interacts with the
+cloud. See [Secure DevOps Best Practices](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/secure/best-practices/secure-devops)
+for a good overview of securing production pipelines.
+
+EOF
+}

--- a/kit/buildingblocks/starterkit/main.tf
+++ b/kit/buildingblocks/starterkit/main.tf
@@ -1,0 +1,67 @@
+# configure our logging subscription
+data "azurerm_subscription" "current" {
+}
+
+resource "azurerm_role_assignment" "terraform_state" {
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = azuread_service_principal.starterkit.object_id
+  scope                = azurerm_storage_container.tfstates.resource_manager_id
+}
+
+# DESIGN: we don't want to permanently hold permissions on all subscriptions via the MG hierarchy
+# this is mean to work in conjunction with the conditional assignment below
+resource "azurerm_role_definition" "starterkit_access" {
+  name              = "${azuread_service_principal.starterkit.display_name}-access"
+  description       = "Allow self-assignment of a role in order access an application team's subscription for deployment"
+  scope             = var.scope
+  assignable_scopes = [var.scope]
+
+  permissions {
+    actions = [
+      "Microsoft.Authorization/roleAssignments/*"
+    ]
+  }
+}
+
+resource "azurerm_role_definition" "starterkit_deploy" {
+  name        = "${azuread_service_principal.starterkit.display_name}-deploy"
+  description = "Enables deployment of starter kits to applicaiton team subscriptions"
+  scope       = var.scope
+
+  permissions {
+    actions = [
+      "Microsoft.Authorization/*/read",
+      "Microsoft.Authorization/roleDefinitions/*",
+      "Microsoft.Authorization/roleAssignments/*",
+      "Microsoft.Resources/subscriptions/resourceGroups/*",
+      "Microsoft.Storage/storageAccounts/*",
+      "Microsoft.ManagedIdentity/*"
+    ]
+  }
+}
+
+resource "azurerm_role_assignment" "starterkit_access" {
+  role_definition_id = azurerm_role_definition.starterkit_access.role_definition_resource_id
+
+  description  = "Allow the ${azuread_service_principal.starterkit.display_name} SPN to grant itself permissions on an application team's subscription to deploy a starterkit building block."
+  principal_id = azuread_service_principal.starterkit.object_id
+  scope        = var.scope
+
+  condition_version = "2.0"
+
+  # what this does: if the request is  not a write and not a delete, pass, else check that it only contains the expected role definition id
+
+  condition = <<-EOT
+(
+  !(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})
+  AND
+  !(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})
+)
+OR
+(
+  @Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {${azurerm_role_definition.starterkit_deploy.role_definition_id}}
+  AND
+  @Request[Microsoft.Authorization/roleAssignments:PrincipalId] ForAnyOfAnyValues:GuidEquals {${azuread_service_principal.starterkit.object_id}}
+)
+EOT
+}

--- a/kit/buildingblocks/starterkit/outputs.tf
+++ b/kit/buildingblocks/starterkit/outputs.tf
@@ -1,0 +1,54 @@
+output "config_tf" {
+  description = "Generates a config.tf that can be dropped into meshStack's BuildingBlockDefinition as an encrypted file input to configure this building block."
+  sensitive   = true
+  value       = <<EOF
+terraform {
+  backend "azurerm" {
+    use_azuread_auth      = true
+    tenant_id             = "${data.azurerm_subscription.current.tenant_id}"
+    subscription_id       = "${data.azurerm_subscription.current.subscription_id}"
+    resource_group_name   = "${azurerm_resource_group.tfstates.name}"
+    storage_account_name  = "${azurerm_storage_account.tfstates.name}"
+    container_name        = "${azurerm_storage_container.tfstates.name}"
+    key                   = "buildingblocks.tfstate"
+
+    client_id             = "${azuread_service_principal.starterkit.client_id}"
+    client_secret         = "${azuread_service_principal_password.starterkit.value}"
+  }
+}
+
+provider "github" {
+  owner = "${var.github_org}"
+
+  app_auth {
+    id              = "${var.github_app_id}"
+    installation_id = "${var.github_app_installation_id}"
+
+    # TODO: ensure the pem file exists on disk in the BB execution environment (with meshStack: secret file input)
+    pem_file = file("./likvid-bank-devops-toolchain-team.private-key.pem")
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = false
+  storage_use_azuread        = true
+
+  tenant_id       = "${data.azurerm_subscription.current.tenant_id}"
+  subscription_id = var.subscription_id
+  client_id       = "${azuread_service_principal.starterkit.client_id}"
+  client_secret   = "${azuread_service_principal_password.starterkit.value}"
+}
+
+locals {
+  deploy_role_definition_id = "${azurerm_role_definition.starterkit_deploy.role_definition_resource_id}"
+}
+
+provider "azuread" {
+  tenant_id       = "${data.azurerm_subscription.current.tenant_id}"
+  client_id       = "${azuread_service_principal.starterkit.client_id}"
+  client_secret   = "${azuread_service_principal_password.starterkit.value}"
+}
+EOF
+}

--- a/kit/buildingblocks/starterkit/resources.bbtfstate.tf
+++ b/kit/buildingblocks/starterkit/resources.bbtfstate.tf
@@ -1,0 +1,26 @@
+resource "random_string" "resource_code" {
+  length  = 5
+  special = false
+  upper   = false
+}
+
+resource "azurerm_resource_group" "tfstates" {
+  name     = "starterkit-buildingblock-tfstates"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "tfstates" {
+  name                      = "tfstates${random_string.resource_code.result}"
+  resource_group_name       = azurerm_resource_group.tfstates.name
+  location                  = azurerm_resource_group.tfstates.location
+  account_tier              = "Standard"
+  account_replication_type  = "GRS"
+  shared_access_key_enabled = false
+}
+
+resource "azurerm_storage_container" "tfstates" {
+  name                  = "tfstates"
+  storage_account_name  = azurerm_storage_account.tfstates.name
+  container_access_type = "blob"
+}
+

--- a/kit/buildingblocks/starterkit/resources.github.tf
+++ b/kit/buildingblocks/starterkit/resources.github.tf
@@ -1,0 +1,4 @@
+resource "github_repository" "staticwebsite_template" {
+  name        = "starterkit-template-azure-static-website"
+  is_template = true
+}

--- a/kit/buildingblocks/starterkit/resources.starterkit-spn.tf
+++ b/kit/buildingblocks/starterkit/resources.starterkit-spn.tf
@@ -1,0 +1,51 @@
+# set up an SPN for the BB execution
+
+data "azuread_group" "project_admins" {
+  # note: this group is managed via meshStack
+  display_name = "devopstoolchain.buildingblocks-prod-admin"
+}
+
+resource "azuread_application" "starterkit" {
+  display_name = "devops-toolchain-starterkit-buildingblock"
+  description  = "This SPN is used by the Likvid Bank DevOps Toolchain team to automate starterkit buildingblocks"
+  owners       = data.azuread_group.project_admins.members
+}
+
+resource "azuread_service_principal" "starterkit" {
+  client_id                    = azuread_application.starterkit.client_id
+  app_role_assignment_required = false
+  owners                       = data.azuread_group.project_admins.members
+}
+
+
+data "azuread_application_published_app_ids" "well_known" {}
+
+data "azuread_service_principal" "msgraph" {
+  client_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+}
+
+# allow reading the groups and users
+resource "azuread_app_role_assignment" "starterkit-directory" {
+  app_role_id        = data.azuread_service_principal.msgraph.app_role_ids["Directory.Read.All"]
+  resource_object_id = data.azuread_service_principal.msgraph.object_id
+
+  principal_object_id = azuread_service_principal.starterkit.object_id
+}
+
+# note this rotation technique requires the terraform to be run regularly
+resource "time_rotating" "key_rotation" {
+  rotation_days = 365
+}
+
+resource "azuread_service_principal_password" "starterkit" {
+  service_principal_id = azuread_service_principal.starterkit.id
+  rotate_when_changed = {
+    rotation = time_rotating.key_rotation.id
+  }
+}
+
+# grant access to the terraform state
+moved {
+  from = azurerm_role_assignment.tfstates_engineers
+  to   = azurerm_role_assignment.terraform_state
+}

--- a/kit/buildingblocks/starterkit/variables.tf
+++ b/kit/buildingblocks/starterkit/variables.tf
@@ -1,0 +1,34 @@
+variable "service_principal_name" {
+  type        = string
+  description = "name of the Service Principal used to perform all deployments of this building block"
+}
+
+variable "location" {
+  type        = string
+  nullable    = false
+  description = "Azure location for deploying the building block terraform state storage account"
+}
+
+variable "scope" {
+  type        = string
+  nullable    = false
+  description = "Scope where the building block should be deployable, typically a Sandbox Landing Zone Management Group"
+}
+
+# unfortunately we can't set up the app via terraform right now, so we need to manually set this up
+# outside of terraform an inject result as vars
+
+variable "github_app_id" {
+  type        = number
+  description = "id of your GitHub App"
+}
+
+variable "github_app_installation_id" {
+  type        = number
+  description = "id of your GitHub App installation as it appears in URLs on GitHub.com"
+}
+
+variable "github_org" {
+  type        = string
+  description = "id of your GitHub organization as it appears in URLs on GitHub.com"
+}

--- a/kit/buildingblocks/starterkit/versions.tf
+++ b/kit/buildingblocks/starterkit/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.71.0"
+    }
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.46.0"
+    }
+
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.42.0"
+    }
+  }
+}
+


### PR DESCRIPTION
First version of the devops tool chain building block

This can be used standalone or as a meshStack building block. In any case the buildinblock backplane is deployed via collie. 

@florianow as a sidenote: The SPN setup in this module is a lot leaner than the one we use in azure/bootstrap (i.e. it has no required_access blocks etc. which iirc are for "grant admin consent"). Maybe we can slim down the azure/bootstrap implementation as well. 

